### PR TITLE
Updated sbt-js-engine to 1.1.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ resolvers ++= Seq(
   "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
 )
 
-addSbtPlugin("com.typesafe.sbt" %% "sbt-js-engine" % "1.0.2")
+addSbtPlugin("com.typesafe.sbt" %% "sbt-js-engine" % "1.1.3")
 
 scalacOptions += "-feature"
 


### PR DESCRIPTION
Hello,

I had trouble compiling typescript code with features from 1.6 version (eg. abstract classes) and noticed that the sbt-js-engine in a convoluted way added typescript-node 1.5.3 version to the project and the plugin used this version instead of 1.6.2. Updating the dependency brings 1.6 features.

Regards,
Marcin Bablok
