### PR TITLE
Add back path-normalization

### DIFF
--- a/src/main/assets/typescript-compiler.ts
+++ b/src/main/assets/typescript-compiler.ts
@@ -143,7 +143,7 @@ namespace sbtts {
       let createResult = (sourceFile: ts.SourceFile): sbtweb.CompilationResult => {
         this.logger.debug(`examining  ${sourceFile.fileName}`);
 
-        let outputFile = inputOutputFileMap[sourceFile.fileName];
+        let outputFile = inputOutputFileMap[this.path.normalize(sourceFile.fileName)];
         let filesWritten = (compilerOptions.outFile) ?
           filesWrittenForSingleFile :
           this.createFilesWrittenArray(outputFile, compilerOptions);
@@ -210,7 +210,7 @@ namespace sbtts {
       let inputOutputFilesMap = this.buildInputOutputFilesMap(inputFiles, compilerOptions);
 
       let sourceFiles: ts.SourceFile[] = compiler.getSourceFiles()
-        .filter((sourceFile: ts.SourceFile) => !!inputOutputFilesMap[sourceFile.fileName]);
+        .filter((sourceFile: ts.SourceFile) => !!inputOutputFilesMap[this.path.normalize(sourceFile.fileName)]);
 
       return {
         results: this.getResults(sourceFiles, compilerOptions, inputOutputFilesMap),


### PR DESCRIPTION
Path-normalization is needed on windows because `inputOutputFilesMap` and `sourceFile.fileName` have different slashes (forward vs backward).
Got removed in 9de85e0829936199cc5e4a372250e7c625e54452
Fixes #71